### PR TITLE
change useparsing to 1

### DIFF
--- a/json2yolo.py
+++ b/json2yolo.py
@@ -80,7 +80,7 @@ def read_json_file_admin(jsonFile):
                 bbox.append(result_tuple_to) 
     return category, bbox, frameName, data
 
-useParsing=0
+useParsing=1
 debug = 0
 writeImagewithBox=1
 annotator=['adam', 'barbara']


### PR DESCRIPTION
Not make sense to try to convert default json example that don't exist actually. In this case for example AIDA_annotation-adam_2233.json don't exist. It's more convenient for google colab people to have it already on 1